### PR TITLE
Add contributor access policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ There are two types of Contributor status:
 
 #### Contributor
 
-Those with the Contributor status have any level of access to the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL)
-repository and the Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
+Those with the Contributor status have a Triage access level to the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
+[Solana](https://github.com/solana-labs/solana) repositories. This status also gets you the Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
 
 #### Core Contributor
 
-Those with the Core Contributor status have any level of access to the [Solana](https://github.com/solana-labs/solana) monorepo and the 
-Core Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
+Those with the Core Contributor status have a Write or Maintain access level to the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
+[Solana](https://github.com/solana-labs/solana) repositories. This status also gets you access to Solana's Buildkite CI and the Core Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
 
-Each Contributor status has 3 levels of Github access, in the order of increasing access:
+#### Access Levels
+
+There are 3 levels of Github access, in the order of increasing access:
 
 1. Triage
 
@@ -25,13 +27,13 @@ Each Contributor status has 3 levels of Github access, in the order of increasin
 
 2. Write
 
-    Requirement: One voucher from anyone with level 3 access or two from
+    Requirement: Two voucher from anyone with level 3 access or two from
 anyone with level 2 access. If only vouched by those with level 2 access, the
 user must have Triage access to be promoted.
 
 3. Maintain
 
-    Requirement: One voucher from anyone with level 3 access. This permission
+    Requirement: Two voucher from anyone with level 3 access. This permission
 is usually reserved for those maintaining the respective repositories.
 
 Each of the levels implies having the previous levels - e.g. level 2 implies
@@ -46,30 +48,30 @@ Requirements: One voucher from any user with level 2 or above access.
 
 Contributors with Triage access will have the associated [triage Github access
 policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
-for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
-[Solana](https://github.com/solana-labs/solana) monorepo.
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the
+[Solana](https://github.com/solana-labs/solana) repositories.
 
 ### Level 2 - Write Access
 
-Requirements: One voucher from anyone with level 3 access or two vouchers from
+Requirements: Two voucher from anyone with level 3 access or two vouchers from
 anyone from level 2. Applicants must have level 1 access to apply for level 2.
 
 Contributors with Write access will have the associated [write Github access
 policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
-for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
-[Solana](https://github.com/solana-labs/solana) monorepo.
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
+[Solana](https://github.com/solana-labs/solana) repositories.
 
 Most notably these permissions allow the contributor to approve and merge pull
-requests.
+requests and gets them access to Solana's Buildkite CI.
 
 ### Level 3 - Maintain Access
 
-Requirements: One voucher from anyone with level 3 access.
+Requirements: Two voucher from anyone with level 3 access.
 
 Contributors will have the associated [maintain Github access
 policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
-for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
-[Solana](https://github.com/solana-labs/solana) monorepo.
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
+[Solana](https://github.com/solana-labs/solana) repositories.
 
 Users with Maintain access are responsible for managing the the repositories and
 granting user access based on the above requirements.
@@ -78,34 +80,41 @@ granting user access based on the above requirements.
 
 To receive a Contributor status and the respective level of access as defined in the Contributor Access Policy, follow these steps:
 
-1. Open an issue on the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository 
+1. Open an issue on the [Contributor Access Policy](https://github.com/solana-labs/contributor-access-policy) repository
 with a title in the following format: "Request Access (Level [X])
 for [Username]". Add information that can help identify you such as your 
 Discord ID in the issue.
 2. Gather your vouchers to add a comment on the issue expressing their support.
 3. Once the issue has received enough support, notify the users with Maintain
 access by adding a comment tagging
-[`@contributors`](https://github.com/orgs/solana-labs/teams/contributors)
+[`@admins`](https://github.com/orgs/solana-labs/teams/admins)
 and you will be granted the requested level of access.
+4. It would take 3 business days for the request to be processed.
 
 To receive a Core Contributor status and the respective level of access as defined in the Contributor Access Policy, follow these steps:
 
-1. Open an issue on the [Solana](https://github.com/solana-labs/solana) monorepo
+1. Open an issue on the [Contributor Access Policy](https://github.com/solana-labs/contributor-access-policy) repository
 with a title in the following format: "Request Access (Level [X])
 for [Username]". Add information that can help identify you such as your 
 Discord ID in the issue.
 2. Gather your vouchers to add a comment on the issue expressing their support.
 3. Once the issue has received enough support, notify the users with Maintain
 access by adding a comment tagging
-[`@core-contributors`](https://github.com/orgs/solana-labs/teams/core-contributors)
+[`@admins`](https://github.com/orgs/solana-labs/teams/admins)
 and you will be granted the requested level of access.
+4. It would take 3 business days for the request to be processed.
+
+**Note**: The vouching comments on the issue should be made in the following format:
+
+```
+"I support the promotion of USER to LEVEL for X reasons"
+```
 
 ### Access Removal Process
 
 In the event that a user requires their access to be removed, follow these steps:
 
-1. Open an issue on the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository 
-or the [Solana](https://github.com/solana-labs/solana) monorepo
+1. Open an issue on the [Contributor Access Policy](https://github.com/solana-labs/contributor-access-policy) repository
 with the title in the following format: "Revoke Access (Level X) for [Username]".
 2. Other users with the appropriate level of access should comment on the issue
 to express their support for the removal of access.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
 ## Summary
 
-This document outlines the procedure for getting Contributor status to various Solana source code repositories and the Solana Tech Discord server.
+This document outlines the procedure for getting contributor access to various Solana Labs source code repositories and the Solana Tech Discord server.
 
-Everyone is welcome to contribute to the Solana codebase. Contributing doesn’t just mean submitting pull requests, 
-there are many different ways for you to get involved, including answering questions on Stack Exchange and Discord, reporting or triaging bugs.
+Everyone is welcome to contribute to the Solana Labs codebase. Contributing doesn’t just mean submitting pull requests, 
+there are many different ways for you to get involved, including answering questions on Stack Exchange or Discord, and reporting or triaging bugs.
 
-There are two types of Contributor status: 
+#### Repositories
 
-#### Contributor
+Access is granted based on the repository you are interested in contributing to:
 
-Those with the Contributor status have a Triage access level to the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
-[Solana](https://github.com/solana-labs/solana) repositories. This status also gets you the Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
-
-#### Core Contributor
-
-Those with the Core Contributor status have a Write or Maintain access level to the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
-[Solana](https://github.com/solana-labs/solana) repositories. This status also gets you access to Solana's Buildkite CI and the Core Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
+1. The [Solana Program Library (SPL) repository](https://github.com/solana-labs/solana-program-library).
+2. The [Solana monorepo](https://github.com/solana-labs/solana).
 
 #### Access Levels
 
@@ -23,85 +18,72 @@ There are 3 levels of Github access, in the order of increasing access:
 
 1. Triage
 
-    Requirement: One voucher from anyone with level 2 or above access.
+    Requirement: One voucher from anyone with level 2 or above access. A contributor with Triage access will be able to manage issues
+in accordance with Github access policies.
 
 2. Write
 
-    Requirement: Two voucher from anyone with level 3 access or two from
-anyone with level 2 access. If only vouched by those with level 2 access, the
-user must have Triage access to be promoted.
+    Requirement: Two vouchers from anyone with level 3 access or two from
+anyone with level 2 access. A contributor with Write access will be able to triage pull requests
+in accordance with Github access policies.
 
 3. Maintain
 
-    Requirement: Two voucher from anyone with level 3 access. This permission
+    Requirement: Two vouchers from anyone with level 3 access. This permission
 is usually reserved for those maintaining the respective repositories.
 
 Each of the levels implies having the previous levels - e.g. level 2 implies
-level 1. A contributor with Write access will be able to triage pull requests
-in accordance with Github access policies.
+level 1. 
 
 ## Detailed Design
 
 ### Level 1 - Triage Access
 
-Requirements: One voucher from any user with level 2 or above access.
+Requirements: One voucher from any user with level 2 or above access to the respective repository.
 
 Contributors with Triage access will have the associated [triage Github access
 policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
-for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the
-[Solana](https://github.com/solana-labs/solana) repositories.
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the
+[Solana](https://github.com/solana-labs/solana) monorepo.
 
 ### Level 2 - Write Access
 
-Requirements: Two voucher from anyone with level 3 access or two vouchers from
-anyone from level 2. Applicants must have level 1 access to apply for level 2.
+Requirements: Two vouchers from anyone with level 3 access or two vouchers from
+anyone with level 2 access to the respective repository. Applicants must have level 1 access to apply for level 2.
 
 Contributors with Write access will have the associated [write Github access
 policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
-for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
-[Solana](https://github.com/solana-labs/solana) repositories.
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
+[Solana](https://github.com/solana-labs/solana) monorepo.
 
 Most notably these permissions allow the contributor to approve and merge pull
-requests and gets them access to Solana's Buildkite CI.
+requests and gets them access to Solana Labs' Buildkite CI.
 
 ### Level 3 - Maintain Access
 
-Requirements: Two voucher from anyone with level 3 access.
+Requirements: Two vouchers from anyone with level 3 access to the respective repository.
 
-Contributors will have the associated [maintain Github access
+Contributors with Maintain access will have the associated [maintain Github access
 policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
-for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) and the 
-[Solana](https://github.com/solana-labs/solana) repositories.
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
+[Solana](https://github.com/solana-labs/solana) monorepo.
 
-Users with Maintain access are responsible for managing the the repositories and
+Users with Maintain access are responsible for managing the repositories and
 granting user access based on the above requirements.
+
+### Discord Access
+
+Any of the above access levels will grant you the Contributor role in the Solana Tech Discord server and a role tag with your current access level and the respective repository (e.g. SLP-Triage, Mono-Triage).
 
 ### Vouching Process 
 
-To receive a Contributor status and the respective level of access as defined in the Contributor Access Policy, follow these steps:
+To receive any access level to the SPL repository or the monorepo, follow these steps:
 
 1. Open an issue on the [Contributor Access Policy](https://github.com/solana-labs/contributor-access-policy) repository
-with a title in the following format: "Request Access (Level [X])
-for [Username]". Add information that can help identify you such as your 
-Discord ID in the issue.
+following the [templates for the respective access level](tbd).
 2. Gather your vouchers to add a comment on the issue expressing their support.
-3. Once the issue has received enough support, notify the users with Maintain
-access by adding a comment tagging
-[`@admins`](https://github.com/orgs/solana-labs/teams/admins)
-and you will be granted the requested level of access.
-4. It would take 3 business days for the request to be processed.
-
-To receive a Core Contributor status and the respective level of access as defined in the Contributor Access Policy, follow these steps:
-
-1. Open an issue on the [Contributor Access Policy](https://github.com/solana-labs/contributor-access-policy) repository
-with a title in the following format: "Request Access (Level [X])
-for [Username]". Add information that can help identify you such as your 
-Discord ID in the issue.
-2. Gather your vouchers to add a comment on the issue expressing their support.
-3. Once the issue has received enough support, notify the users with Maintain
-access by adding a comment tagging
-[`@admins`](https://github.com/orgs/solana-labs/teams/admins)
-and you will be granted the requested level of access.
+3. Once the issue has received enough support, notify a user with Maintain
+access to the respective repository by adding a comment tagging him. A list of members and their access levels can be found [here](https://github.com/solana-labs/contributor-access-policy/wiki). 
 4. It would take 3 business days for the request to be processed.
 
 **Note**: The vouching comments on the issue should be made in the following format:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,127 @@
-# contributor-access-policy
+## Summary
+
 This document outlines the procedure for getting Contributor status to various Solana source code repositories and the Solana Tech Discord server.
+
+Everyone is welcome to contribute to the Solana codebase. Contributing doesn’t just mean submitting pull requests, 
+there are many different ways for you to get involved, including answering questions on Stack Exchange and Discord, reporting or triaging bugs.
+
+There are two types of Contributor status: 
+
+#### Contributor
+
+Those with the Contributor status have any level of access to the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL)
+repository and the Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
+
+#### Core Contributor
+
+Those with the Core Contributor status have any level of access to the [Solana](https://github.com/solana-labs/solana) monorepo and the 
+Core Contributor role in the [Solana Tech Discord](https://discordapp.com/invite/pquxPsq).
+
+Each Contributor status has 3 levels of Github access, in the order of increasing access:
+
+1. Triage
+
+    Requirement: One voucher from anyone with level 2 or above access.
+
+2. Write
+
+    Requirement: One voucher from anyone with level 3 access or two from
+anyone with level 2 access. If only vouched by those with level 2 access, the
+user must have Triage access to be promoted.
+
+3. Maintain
+
+    Requirement: One voucher from anyone with level 3 access. This permission
+is usually reserved for those maintaining the respective repositories.
+
+Each of the levels implies having the previous levels - e.g. level 2 implies
+level 1. A contributor with Write access will be able to triage pull requests
+in accordance with Github access policies.
+
+## Detailed Design
+
+### Level 1 - Triage Access
+
+Requirements: One voucher from any user with level 2 or above access.
+
+Contributors with Triage access will have the associated [triage Github access
+policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
+[Solana](https://github.com/solana-labs/solana) monorepo.
+
+### Level 2 - Write Access
+
+Requirements: One voucher from anyone with level 3 access or two vouchers from
+anyone from level 2. Applicants must have level 1 access to apply for level 2.
+
+Contributors with Write access will have the associated [write Github access
+policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
+[Solana](https://github.com/solana-labs/solana) monorepo.
+
+Most notably these permissions allow the contributor to approve and merge pull
+requests.
+
+### Level 3 - Maintain Access
+
+Requirements: One voucher from anyone with level 3 access.
+
+Contributors will have the associated [maintain Github access
+policy](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)
+for the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository or the 
+[Solana](https://github.com/solana-labs/solana) monorepo.
+
+Users with Maintain access are responsible for managing the the repositories and
+granting user access based on the above requirements.
+
+### Vouching Process 
+
+To receive a Contributor status and the respective level of access as defined in the Contributor Access Policy, follow these steps:
+
+1. Open an issue on the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository 
+with a title in the following format: "Request Access (Level [X])
+for [Username]". Add information that can help identify you such as your 
+Discord ID in the issue.
+2. Gather your vouchers to add a comment on the issue expressing their support.
+3. Once the issue has received enough support, notify the users with Maintain
+access by adding a comment tagging
+[`@contributors`](https://github.com/orgs/solana-labs/teams/contributors)
+and you will be granted the requested level of access.
+
+To receive a Core Contributor status and the respective level of access as defined in the Contributor Access Policy, follow these steps:
+
+1. Open an issue on the [Solana](https://github.com/solana-labs/solana) monorepo
+with a title in the following format: "Request Access (Level [X])
+for [Username]". Add information that can help identify you such as your 
+Discord ID in the issue.
+2. Gather your vouchers to add a comment on the issue expressing their support.
+3. Once the issue has received enough support, notify the users with Maintain
+access by adding a comment tagging
+[`@core-contributors`](https://github.com/orgs/solana-labs/teams/core-contributors)
+and you will be granted the requested level of access.
+
+### Access Removal Process
+
+In the event that a user requires their access to be removed, follow these steps:
+
+1. Open an issue on the [Solana Program Library](https://github.com/solana-labs/solana-program-library) (SPL) repository 
+or the [Solana](https://github.com/solana-labs/solana) monorepo
+with the title in the following format: "Revoke Access (Level X) for [Username]".
+2. Other users with the appropriate level of access should comment on the issue
+to express their support for the removal of access.
+3. Once the issue has received enough support, the user's access will be
+revoked.
+
+Requirements:
+
+- If a user's level 3 access is being revoked, support from at least two other
+users with level 3 access is required.
+- If a user's level 1 or 2 access is being revoked, support from at least two 
+other users with level 2 or one user with level 3 is required.
+- If a user opens the issue to revoke their own access, no support from others
+is required.
+
+## Security Considerations
+
+In the event of a malicious actor gaining any level of access, users must
+follow the Access Removal Process to revoke that actor's access.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ in accordance with Github access policies.
 2. Write
 
     Requirement: Two vouchers from anyone with level 3 access or two from
-anyone with level 2 access. A contributor with Write access will be able to triage pull requests
+anyone with level 2 access. A contributor with Write access will be able to merge pull requests
 in accordance with Github access policies.
 
 3. Maintain


### PR DESCRIPTION
**Problem**

There isn't a clear path on how to grant Contributor or Core Contributor status that includes triage, write, or maintain access to the Solana Program Library (SPL) repository and the Solana monorepo, as well as the respective roles in the Solana Tech Discord server. 

**Solution**

Draft a Contributor Access Policy to let people obtain the Contributor and Core Contributor status. 

