### PR TITLE
reference permissions instead of levels in request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/monorepo-triage.yaml
+++ b/.github/ISSUE_TEMPLATE/monorepo-triage.yaml
@@ -1,6 +1,6 @@
 name: Monorepo Triage Access Request
-description: Issue template to request Level 1 access to the Solana Labs Monorepo
-title: "Access Level 1 for [User] to the Solana Labs Monorepo"
+description: Issue template to request Triage access to the Solana Labs Monorepo
+title: "Request Triage access for [User] to the Solana Labs Monorepo"
 labels: ["access"]
 assignees:
   - joeaba

--- a/.github/ISSUE_TEMPLATE/monorepo-write.yaml
+++ b/.github/ISSUE_TEMPLATE/monorepo-write.yaml
@@ -1,6 +1,6 @@
 name: Monorepo Write Access Request
-description: Issue template to request Level 2 access to the Solana Labs Monorepo
-title: "Access Level 2 for [User] to the Solana Labs Monorepo"
+description: Issue template to request Write access to the Solana Labs Monorepo
+title: "Request Write access for [User] to the Solana Labs Monorepo"
 labels: ["access"]
 assignees:
   - joeaba
@@ -34,8 +34,8 @@ body:
   - type: input
     id: previous_access_issue
     attributes:
-      label: Previously approved access level 1 issue
-      description: Link to previously approved access issue
+      label: Previously approved Triage access request issue
+      description: Link to previously approved access request issue
       placeholder: ex. https://github.com/solana-labs/contributor-access-policy/issues/X
     validations:
       required: true  

--- a/.github/ISSUE_TEMPLATE/spl-triage.yaml
+++ b/.github/ISSUE_TEMPLATE/spl-triage.yaml
@@ -1,6 +1,6 @@
 name: SPL Triage Access Request
-description: Issue template to request Level 1 access to the SPL repository
-title: "Access Level 1 for [User] to the SPL repository"
+description: Issue template to request Triage access to the SPL repository
+title: "Request Triage access for [User] to the SPL repository"
 labels: ["access"]
 assignees:
   - joeaba

--- a/.github/ISSUE_TEMPLATE/spl-write.yaml
+++ b/.github/ISSUE_TEMPLATE/spl-write.yaml
@@ -1,6 +1,6 @@
 name: SPL Write Access Request
-description: Issue template to request Level 2 access to the SPL repository
-title: "Access Level 2 for [User] to the SPL repository"
+description: Issue template to request Write access to the SPL repository
+title: "Request Write access for [User] to the SPL repository"
 labels: ["access"]
 assignees:
   - joeaba
@@ -35,8 +35,8 @@ body:
   - type: input
     id: previous_access_issue
     attributes:
-      label: Previously approved access level 1 issue
-      description: URL to previously approved issue for Access Level 1 to the SPL repository
+      label: Previously approved Triage access request issue
+      description: Link to previously approved access request issue
       placeholder: ex. https://github.com/solana-labs/contributor-access-policy/issues/X
     validations:
       required: true  


### PR DESCRIPTION
"Level N" is hard to keep track of, use the actual permission names instead