### PR TITLE
ci: add on board pipeline

### DIFF
--- a/.github/workflows/on-board.yml
+++ b/.github/workflows/on-board.yml
@@ -167,6 +167,7 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.PAT }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -179,16 +180,6 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               name: "${{ github.event.label.name }}"
-            })
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              state: 'closed',
-              state_reasonstring: 'completed'
             })
 
   on_failure:

--- a/.github/workflows/on-board.yml
+++ b/.github/workflows/on-board.yml
@@ -20,27 +20,8 @@ jobs:
               body: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             })
 
-  check_privilege:
-    needs: [link_to_issue]
-    runs-on: ubuntu-latest
-    steps:
-      - name: check privilege
-        run: |
-          maintainers=(
-            "mvines"
-            "CriesofCarrots"
-            "joeaba"
-            "t-nelson"
-            "sakridge"
-            "yihau"
-            "joncinque"
-          )
-          if [[ ! " ${maintainers[*]} " =~ " ${{github.event.sender.login}} " ]]; then
-            exit 1
-          fi
-
   parse_info:
-    needs: check_privilege
+    needs: link_to_issue
     runs-on: ubuntu-latest
     outputs:
       org: ${{ steps.main.outputs.org }}
@@ -101,9 +82,51 @@ jobs:
           echo "previous_team_slug=$previous_team_slug" >> $GITHUB_OUTPUT
           echo "team_slug=$team_slug" >> $GITHUB_OUTPUT
 
-  remove_from_previous_team:
+  check_privilege_for_mono:
     needs: [parse_info]
-    if: needs.parse_info.outputs.previous_team_slug != ''
+    if: contains(needs.parse_info.outputs.team_slug, 'monorepo')
+    runs-on: ubuntu-latest
+    steps:
+      - name: check privilege
+        run: |
+          maintainers=(
+            "mvines"
+            "CriesofCarrots"
+            "joeaba"
+            "t-nelson"
+            "sakridge"
+            "yihau"
+          )
+          if [[ ! " ${maintainers[*]} " =~ " ${{github.event.sender.login}} " ]]; then
+            exit 1
+          fi
+
+  check_privilege_for_spl:
+    needs: [parse_info]
+    if: contains(needs.parse_info.outputs.team_slug, 'spl')
+    runs-on: ubuntu-latest
+    steps:
+      - name: check privilege
+        run: |
+          maintainers=(
+            "mvines"
+            "CriesofCarrots"
+            "joeaba"
+            "t-nelson"
+            "sakridge"
+            "yihau"
+            "joncinque"
+          )
+          if [[ ! " ${maintainers[*]} " =~ " ${{github.event.sender.login}} " ]]; then
+            exit 1
+          fi
+
+  remove_from_previous_team:
+    needs: [parse_info, check_privilege_for_mono, check_privilege_for_spl]
+    if: |
+      always() &&
+      (needs.parse_info.outputs.previous_team_slug != '') &&
+      (needs.check_privilege_for_mono.result == 'success' || needs.check_privilege_for_spl.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6
@@ -117,12 +140,14 @@ jobs:
             })
 
   add_to_team:
-    needs: [parse_info]
-    if: needs.parse_info.outputs.team_slug != ''
+    needs: [parse_info, check_privilege_for_mono, check_privilege_for_spl]
+    if: |
+      always() &&
+      (needs.parse_info.outputs.team_slug != '') &&
+      (needs.check_privilege_for_mono.result == 'success' || needs.check_privilege_for_spl.result == 'success')
     runs-on: ubuntu-latest
     steps:
-      - name: add to team
-        uses: actions/github-script@v6
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.PAT }}
           script: |

--- a/.github/workflows/on-board.yml
+++ b/.github/workflows/on-board.yml
@@ -1,0 +1,182 @@
+name: on-board
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  link_to_issue:
+    if: github.event.label.name == 'processing'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            })
+
+  check_privilege:
+    needs: [link_to_issue]
+    runs-on: ubuntu-latest
+    steps:
+      - name: check privilege
+        run: |
+          maintainers=(
+            "mvines"
+            "CriesofCarrots"
+            "joeaba"
+            "t-nelson"
+            "sakridge"
+            "yihau"
+            "joncinque"
+          )
+          if [[ ! " ${maintainers[*]} " =~ " ${{github.event.sender.login}} " ]]; then
+            exit 1
+          fi
+
+  parse_info:
+    needs: check_privilege
+    runs-on: ubuntu-latest
+    outputs:
+      org: ${{ steps.main.outputs.org }}
+      username: ${{ steps.main.outputs.username }}
+      previous_team_slug: ${{ steps.main.outputs.previous_team_slug }}
+      team_slug: ${{ steps.main.outputs.team_slug }}
+    steps:
+      - id: main
+        run: |
+          regex="Request (.*) access for (.*) to the (.*)"
+          if [[ ! "${{ github.event.issue.title }}" =~ $regex ]]
+          then
+            exit 1
+          else
+            privilege="${BASH_REMATCH[1]}"
+            username="${BASH_REMATCH[2]}"
+            repo="${BASH_REMATCH[3]}"
+
+            previous_team_slug=
+            team_slug=
+            case `echo $repo | sed -e 's/^[[:space:]]*//'` in
+              "Solana Labs Monorepo")
+                case $privilege in
+                  "Triage")
+                    team_slug="monorepo-triage"
+                  ;;
+                  "Write")
+                    previous_team_slug="monorepo-triage"
+                    team_slug="monorepo-write"
+                  ;;
+                  *)
+                    exit 1
+                  ;;
+                esac
+              ;;
+              "SPL repository")
+                case $privilege in
+                  "Triage")
+                    team_slug="spl-triage"
+                  ;;
+                  "Write")
+                    previous_team_slug="spl-triage"
+                    team_slug="spl-write"
+                  ;;
+                  *)
+                    exit 1
+                  ;;
+                esac
+              ;;
+              *)
+                exit 1
+              ;;
+            esac
+          fi
+
+          echo "org=solana-labs" >> $GITHUB_OUTPUT
+          echo "username=$username" >> $GITHUB_OUTPUT
+          echo "previous_team_slug=$previous_team_slug" >> $GITHUB_OUTPUT
+          echo "team_slug=$team_slug" >> $GITHUB_OUTPUT
+
+  remove_from_previous_team:
+    needs: [parse_info]
+    if: needs.parse_info.outputs.previous_team_slug != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            github.rest.teams.removeMembershipForUserInOrg({
+              org: "${{ needs.parse_info.outputs.org }}",
+              team_slug: "${{ needs.parse_info.outputs.previous_team_slug }}",
+              username: "${{ needs.parse_info.outputs.username }}"
+            })
+
+  add_to_team:
+    needs: [parse_info]
+    if: needs.parse_info.outputs.team_slug != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: add to team
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            github.rest.teams.addOrUpdateMembershipForUserInOrg({
+              org: "${{ needs.parse_info.outputs.org }}",
+              team_slug: "${{ needs.parse_info.outputs.team_slug }}",
+              username: "${{ needs.parse_info.outputs.username }}"
+            })
+
+  on_success:
+    needs: [add_to_team, remove_from_previous_team]
+    if: |
+      always() &&
+      (needs.add_to_team.result == 'success') &&
+      (needs.remove_from_previous_team.result == 'success' || needs.remove_from_previous_team.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["approved"]
+            })
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: "${{ github.event.label.name }}"
+            })
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reasonstring: 'completed'
+            })
+
+  on_failure:
+    needs: [add_to_team, remove_from_previous_team]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: "${{ github.event.label.name }}"
+            })

--- a/.github/workflows/update-acl.yml
+++ b/.github/workflows/update-acl.yml
@@ -1,0 +1,122 @@
+name: update-acl
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  check_permission:
+    if: github.event.label.name == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: check privilege
+        run: |
+          echo "${{github.event.sender.login}}"
+
+  parse_info:
+    needs: [check_permission]
+    runs-on: ubuntu-latest
+    outputs:
+      file_path: ${{ steps.main.outputs.file_path }}
+      level: ${{ steps.main.outputs.level }}
+      github_username: ${{ steps.main.outputs.github_username }}
+      discord_username: ${{ steps.main.outputs.discord_username }}
+    steps:
+      - id: main
+        shell: bash
+        run: |
+          body="${{ github.event.issue.body }}"
+          body=${body//$'\r'/}
+          body=${body//$'\n'/}
+          body=${body//$'\r\n'/}
+          regex="### GitHub Username[\r|\n|\r\n]*([0-9a-zA-Z-]*)[\r|\n|\r\n]*### Discord ID[\r|\n|\r\n]*(.{3,32}#[0-9]{4})"
+          if [[ ! $body =~ $regex ]]; then
+            echo "failed to parse issue body: $body"
+            exit 1
+          fi
+          github_username="${BASH_REMATCH[1]}"
+          discord_username="${BASH_REMATCH[2]}"
+          echo "github_username=$github_username" >> $GITHUB_OUTPUT
+          echo "discord_username=$discord_username" >> $GITHUB_OUTPUT
+
+          title="${{ github.event.issue.title }}"
+          regex="Request (.*) access for (.*) to the (.*)"
+          if [[ ! $title =~ $regex ]]
+          then
+            echo "failed to parse issue title: $title"
+            exit 1
+          else
+            privilege="${BASH_REMATCH[1]}"
+            repo="${BASH_REMATCH[3]}"
+
+            file_path=
+            case `echo $repo | sed -e 's/^[[:space:]]*//'` in
+              "Solana Labs Monorepo")
+                file_path=access-control-list/monorepo-member-access.md
+              ;;
+              "SPL repository")
+                file_path=access-control-list/spl-member-access.md
+              ;;
+              *)
+                exit 1
+              ;;
+            esac
+            echo "file_path=$file_path" >> $GITHUB_OUTPUT
+
+            level=
+            case $privilege in
+              "Triage")
+                level=1
+              ;;
+              "Write")
+                level=2
+              ;;
+              *)
+                exit 1
+              ;;
+            esac
+            echo "level=$level" >> $GITHUB_OUTPUT
+          fi
+
+          echo "github_username=$github_username"
+          echo "discord_username=$discord_username"
+          echo "file_path=$file_path"
+          echo "level=$level"
+
+  update_acl:
+    needs: [parse_info]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - if: needs.parse_info.outputs.level == 1
+        run: |
+          echo "| ${{ needs.parse_info.outputs.github_username }} | ${{ needs.parse_info.outputs.discord_username }} | ${{ needs.parse_info.outputs.level }} |" >> ${{ needs.parse_info.outputs.file_path }}
+
+      - if: needs.parse_info.outputs.level == 2
+        run: |
+          sed -i -e 's/|\(.*${{ needs.parse_info.outputs.github_username }}.*\)|\(.*${{ needs.parse_info.outputs.discord_username }}.*\)|\(.*\)|/|\1|\2| ${{ needs.parse_info.outputs.level }} |/g' ${{ needs.parse_info.outputs.file_path }}
+
+      - name: push
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add ${{ needs.parse_info.outputs.file_path }}
+          git commit -m "update acl"
+          git push
+
+  close:
+    needs: [update_acl]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reasonstring: 'completed'
+            })

--- a/.github/workflows/update-acl.yml
+++ b/.github/workflows/update-acl.yml
@@ -12,7 +12,12 @@ jobs:
     steps:
       - name: check privilege
         run: |
-          echo "${{github.event.sender.login}}"
+          maintainers=(
+            "joeaba"
+          )
+          if [[ ! " ${maintainers[*]} " =~ " ${{github.event.sender.login}} " ]]; then
+            exit 1
+          fi
 
   parse_info:
     needs: [check_permission]


### PR DESCRIPTION
### Problem

Maybe we need a on board pipeline to add people to team.

### Summary of Changes

There are two pipelines. one is for managing team and another is for update account list.

#### Add user to team

<img width="1118" alt="Screenshot 2023-02-08 at 11 40 03 PM" src="https://user-images.githubusercontent.com/8209234/217577690-46553c95-ac70-4b22-82bb-9cb5b226f9ff.png">
<img width="1132" alt="Screenshot 2023-02-08 at 11 40 12 PM" src="https://user-images.githubusercontent.com/8209234/217577700-ca914635-b006-4eb4-ab42-800891194f51.png">

We can add a label 'processing' to a qualified issue to trigger this pipeline. The pipeline will:

1. check the label name

2. parse issue's title to get info
 
3. check permission for the person who labeled

4. add users to team and remove users from the team of previous level if needed

5. 
    on success => a) remove 'processing' label b) add 'approved' label with a PAT (for triggering next pipeline)
    on failure => remove 'processing' when failed

#### Update account list

![Screenshot 2023-02-11 at 1 45 38 AM](https://user-images.githubusercontent.com/8209234/218160314-e941f8bf-fb76-4e3c-a372-891e7fe834a7.png)

the previous pipeline will add `approved` label to the issue. it will trigger this pipeline.

1. check permisstion (for now I only add Joe cuz I think we will use Joe's PAT)
2. parse issue's body to get `github_username` and `discord_username` and issue's title to know which files need to be modified with the respective level
3. update file and push. there are two situations:
    a) level 1 => add it to the end of the file
    b) level 2 => I suppose it has already on the file so I just change its level by sed. (I won't sort it, I think keep level 3 on the top is enough)
4. close the issue

Before merging this one, we need to setup a `PAT` which's privilege can add people to team (including outside contributors) and add label to issues.


